### PR TITLE
support for output binary and base64 encoded data

### DIFF
--- a/src/MDAvatars.php
+++ b/src/MDAvatars.php
@@ -427,6 +427,32 @@ class MDAvatars
         return imagepng($this->Resize($AvatarSize));
     }
 
+    /**
+     * Output binary image data
+     * @param int $AvatarSize
+     * @return resource
+     */
+    public function Output2Binary($AvatarSize = 0)
+    {
+        if (!$AvatarSize) {
+            $AvatarSize = $this->AvatarSize;
+        }
+        return $this->Resize($AvatarSize);
+    }
+
+    /**
+     * Output Base64 encoded image data
+     * @param int $AvatarSize
+     * @return string
+     */
+    public function Output2Base64($AvatarSize = 0)
+    {
+        if (!$AvatarSize) {
+            $AvatarSize = $this->AvatarSize;
+        }
+        return 'data:image/png;base64,' . base64_encode($this->Resize($AvatarSize));
+    }
+
     public function Save($Path, $AvatarSize = 0)
     {
         if (!$AvatarSize) {


### PR DESCRIPTION
你好，lincanbin

Output2Browser方法强制设置了Content-Type和通过imagepng输出，这导致了在一些框架中无法很好的处理数据。
因为我添加了Output2Binary和Output2Base64函数，数据处理后交给框架来决定如何显示。